### PR TITLE
Audit backend

### DIFF
--- a/src/main/css/table.css
+++ b/src/main/css/table.css
@@ -18,17 +18,17 @@
 
 .addJobButton {
 	composes: tableButton;
-    background: #285f8f;
+    background-color: #285f8f;
 }
 
 .deleteJobButton {
 	composes: tableButton;
-    background: #ef4923;
+    background-color: #ef4923;
 }
 
 .editJobButton {
     composes: tableButton;
-    background: #285f8f;
+    background-color: #285f8f;
     margin-left: auto;
     margin-right: auto;
 }
@@ -39,6 +39,11 @@
 
 .tableRow {
     cursor: pointer;
+}
+
+.tableEvenRow {
+    composes: tableRow;
+    background-color: #f9f9f9;
 }
 
 .tableCell {

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/ChannelTemplateManager.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/ChannelTemplateManager.java
@@ -96,12 +96,11 @@ public class ChannelTemplateManager {
                 final List<String> ids = channelEvent.getProjectData().getNotificationIds().stream().map(id -> id.toString()).collect(Collectors.toList());
                 // TODO remove println
                 System.out.println("Notification Id's : " + StringUtils.join(ids.toArray()));
+                System.out.println("Event " + channelEvent);
                 // TODO update AuditEntryEntity to handle multiple notifications
-                final AuditEntryEntity auditEntryEntity = new AuditEntryEntity(channelEvent.getCommonDistributionConfigId(), new Date(), null, null, null, null);
-                final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(auditEntryEntity);
+                final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(new AuditEntryEntity(channelEvent.getCommonDistributionConfigId(), new Date(), null, null, null, null));
                 // FIXME WHY IS THE ID NOT BEING GENERATED??
                 channelEvent.setAuditEntryId(savedAuditEntryEntity.getId());
-                System.out.println("Audit " + auditEntryEntity);
                 System.out.println("Saved Audit " + savedAuditEntryEntity);
                 // TODO remove println
                 System.out.println("Audit Entity Id : " + channelEvent.getAuditEntryId());

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/ChannelTemplateManager.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/ChannelTemplateManager.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
+import javax.transaction.Transactional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,7 @@ import com.blackducksoftware.integration.hub.alert.event.AbstractChannelEvent;
 import com.blackducksoftware.integration.hub.alert.event.AbstractEvent;
 import com.google.gson.Gson;
 
+@Transactional
 @Component
 public class ChannelTemplateManager {
     private final Map<String, AbstractJmsTemplate> jmsTemplateMap;
@@ -95,10 +97,10 @@ public class ChannelTemplateManager {
                 final AbstractChannelEvent channelEvent = (AbstractChannelEvent) event;
                 final List<String> ids = channelEvent.getProjectData().getNotificationIds().stream().map(id -> id.toString()).collect(Collectors.toList());
                 // TODO remove println
-                System.out.println("Notification Id's : " + StringUtils.join(ids.toArray()));
+                System.out.println("Notification Id's : " + StringUtils.join(ids.toArray(), ","));
                 System.out.println("Event " + channelEvent);
                 // TODO update AuditEntryEntity to handle multiple notifications
-                final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(new AuditEntryEntity(channelEvent.getCommonDistributionConfigId(), new Date(), null, null, null, null));
+                final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(new AuditEntryEntity(channelEvent.getCommonDistributionConfigId(), new Date(System.currentTimeMillis()), null, null, null, null));
                 // FIXME WHY IS THE ID NOT BEING GENERATED??
                 channelEvent.setAuditEntryId(savedAuditEntryEntity.getId());
                 System.out.println("Saved Audit " + savedAuditEntryEntity);

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/DistributionChannel.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/DistributionChannel.java
@@ -74,7 +74,7 @@ public abstract class DistributionChannel<E extends AbstractChannelEvent, G exte
                 logger.error("AUDIT ENTRY WAS NOT NULL setting success");
                 auditEntryEntity.setStatus(StatusEnum.SUCCESS);
 
-                auditEntryEntity.setTimeLastSent(new Date());
+                auditEntryEntity.setTimeLastSent(new Date(System.currentTimeMillis()));
                 getAuditEntryRepository().save(auditEntryEntity);
             }
         }
@@ -91,7 +91,7 @@ public abstract class DistributionChannel<E extends AbstractChannelEvent, G exte
                 e.printStackTrace(new PrintWriter(stringWriter));
                 auditEntryEntity.setErrorStackTrace(stringWriter.toString());
 
-                auditEntryEntity.setTimeLastSent(new Date());
+                auditEntryEntity.setTimeLastSent(new Date(System.currentTimeMillis()));
                 getAuditEntryRepository().save(auditEntryEntity);
             }
         }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/DistributionChannel.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/DistributionChannel.java
@@ -22,6 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.alert.channel;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Date;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -29,10 +32,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.blackducksoftware.integration.hub.alert.MessageReceiver;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.AuditEntryEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.CommonDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.DistributionChannelConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.global.GlobalChannelConfigEntity;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
+import com.blackducksoftware.integration.hub.alert.enumeration.StatusEnum;
 import com.blackducksoftware.integration.hub.alert.event.AbstractChannelEvent;
 import com.google.gson.Gson;
 
@@ -42,16 +48,53 @@ public abstract class DistributionChannel<E extends AbstractChannelEvent, G exte
     private final JpaRepository<G, Long> globalRepository;
     private final JpaRepository<C, Long> distributionRepository;
     private final CommonDistributionRepository commonDistributionRepository;
+    private final AuditEntryRepository auditEntryRepository;
 
-    public DistributionChannel(final Gson gson, final JpaRepository<G, Long> globalRepository, final JpaRepository<C, Long> distributionRepository, final CommonDistributionRepository commonDistributionRepository, final Class<E> clazz) {
+    public DistributionChannel(final Gson gson, final AuditEntryRepository auditEntryRepository, final JpaRepository<G, Long> globalRepository, final JpaRepository<C, Long> distributionRepository,
+            final CommonDistributionRepository commonDistributionRepository, final Class<E> clazz) {
         super(gson, clazz);
+        this.auditEntryRepository = auditEntryRepository;
         this.globalRepository = globalRepository;
         this.distributionRepository = distributionRepository;
         this.commonDistributionRepository = commonDistributionRepository;
     }
 
+    public AuditEntryRepository getAuditEntryRepository() {
+        return auditEntryRepository;
+    }
+
     public CommonDistributionRepository getCommonDistributionRepository() {
         return commonDistributionRepository;
+    }
+
+    public void setAuditEntrySuccess(final Long auditEntryId) {
+        if (auditEntryId != null) {
+            final AuditEntryEntity auditEntryEntity = getAuditEntryRepository().findOne(auditEntryId);
+            if (auditEntryEntity != null) {
+                logger.error("AUDIT ENTRY WAS NOT NULL setting success");
+                auditEntryEntity.setStatus(StatusEnum.SUCCESS);
+
+                auditEntryEntity.setTimeLastSent(new Date());
+                getAuditEntryRepository().save(auditEntryEntity);
+            }
+        }
+    }
+
+    public void setAuditEntryFailure(final Long auditEntryId, final String errorMessage, final Throwable e) {
+        if (auditEntryId != null) {
+            final AuditEntryEntity auditEntryEntity = getAuditEntryRepository().findOne(auditEntryId);
+            if (auditEntryEntity != null) {
+                logger.error("AUDIT ENTRY WAS NOT NULL setting failure");
+                auditEntryEntity.setStatus(StatusEnum.FAILURE);
+                auditEntryEntity.setErrorMessage(errorMessage);
+                final StringWriter stringWriter = new StringWriter();
+                e.printStackTrace(new PrintWriter(stringWriter));
+                auditEntryEntity.setErrorStackTrace(stringWriter.toString());
+
+                auditEntryEntity.setTimeLastSent(new Date());
+                getAuditEntryRepository().save(auditEntryEntity);
+            }
+        }
     }
 
     public G getGlobalConfigEntity() {

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/hipchat/HipChatChannel.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/hipchat/HipChatChannel.java
@@ -93,6 +93,9 @@ public class HipChatChannel extends DistributionChannel<HipChatEvent, GlobalHipC
                 logger.error(((IntegrationRestException) e).getHttpStatusCode() + ":" + ((IntegrationRestException) e).getHttpStatusMessage());
             }
             logger.error(e.getMessage(), e);
+        } catch (final Exception e) {
+            setAuditEntryFailure(event.getAuditEntryId(), e.getMessage(), e);
+            logger.error(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/hipchat/HipChatChannel.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/hipchat/HipChatChannel.java
@@ -44,6 +44,7 @@ import com.blackducksoftware.integration.hub.alert.channel.SupportedChannels;
 import com.blackducksoftware.integration.hub.alert.config.GlobalProperties;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.HipChatDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.global.GlobalHipChatConfigEntity;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.HipChatDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.global.GlobalHipChatRepository;
@@ -67,9 +68,9 @@ public class HipChatChannel extends DistributionChannel<HipChatEvent, GlobalHipC
     private final GlobalProperties globalProperties;
 
     @Autowired
-    public HipChatChannel(final Gson gson, final GlobalProperties globalProperties, final GlobalHipChatRepository globalHipChatRepository, final CommonDistributionRepository commonDistributionRepository,
-            final HipChatDistributionRepository hipChatDistributionRepository) {
-        super(gson, globalHipChatRepository, hipChatDistributionRepository, commonDistributionRepository, HipChatEvent.class);
+    public HipChatChannel(final Gson gson, final AuditEntryRepository auditEntryRepository, final GlobalProperties globalProperties, final GlobalHipChatRepository globalHipChatRepository,
+            final CommonDistributionRepository commonDistributionRepository, final HipChatDistributionRepository hipChatDistributionRepository) {
+        super(gson, auditEntryRepository, globalHipChatRepository, hipChatDistributionRepository, commonDistributionRepository, HipChatEvent.class);
         this.globalProperties = globalProperties;
     }
 
@@ -84,7 +85,10 @@ public class HipChatChannel extends DistributionChannel<HipChatEvent, GlobalHipC
         final String htmlMessage = createHtmlMessage(event.getProjectData());
         try {
             sendMessage(config, HIP_CHAT_API, htmlMessage, AlertConstants.ALERT_APPLICATION_NAME);
+            setAuditEntrySuccess(event.getAuditEntryId());
         } catch (final IntegrationException e) {
+            setAuditEntryFailure(event.getAuditEntryId(), e.getMessage(), e);
+
             if (e instanceof IntegrationRestException) {
                 logger.error(((IntegrationRestException) e).getHttpStatusCode() + ":" + ((IntegrationRestException) e).getHttpStatusMessage());
             }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/manager/DistributionChannelManager.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/manager/DistributionChannelManager.java
@@ -66,7 +66,7 @@ public abstract class DistributionChannelManager<G extends GlobalChannelConfigEn
     }
 
     public ProjectData getTestMessageProjectData() {
-        return new ProjectData(DigestTypeEnum.REAL_TIME, "Hub Alert", "Test Message", Collections.emptyMap());
+        return new ProjectData(DigestTypeEnum.REAL_TIME, "Hub Alert", "Test Message", Collections.emptyList(), Collections.emptyMap());
     }
 
     public String sendTestMessage(final R restModel) throws AlertException {

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/slack/SlackChannel.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/slack/SlackChannel.java
@@ -38,6 +38,7 @@ import com.blackducksoftware.integration.hub.alert.channel.SupportedChannels;
 import com.blackducksoftware.integration.hub.alert.config.GlobalProperties;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.SlackDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.global.GlobalSlackConfigEntity;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.SlackDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.digest.model.CategoryData;
@@ -62,8 +63,9 @@ public class SlackChannel extends DistributionChannel<SlackEvent, GlobalSlackCon
     private final GlobalProperties globalProperties;
 
     @Autowired
-    public SlackChannel(final Gson gson, final SlackDistributionRepository slackDistributionRepository, final CommonDistributionRepository commonDistributionRepository, final GlobalProperties globalProperties) {
-        super(gson, null, slackDistributionRepository, commonDistributionRepository, SlackEvent.class);
+    public SlackChannel(final Gson gson, final AuditEntryRepository auditEntryRepository, final SlackDistributionRepository slackDistributionRepository, final CommonDistributionRepository commonDistributionRepository,
+            final GlobalProperties globalProperties) {
+        super(gson, auditEntryRepository, null, slackDistributionRepository, commonDistributionRepository, SlackEvent.class);
         this.globalProperties = globalProperties;
     }
 
@@ -73,7 +75,10 @@ public class SlackChannel extends DistributionChannel<SlackEvent, GlobalSlackCon
         final String htmlMessage = createMessage(projectData);
         try {
             sendMessage(htmlMessage, config);
+            setAuditEntrySuccess(event.getAuditEntryId());
         } catch (final IntegrationException e) {
+            setAuditEntryFailure(event.getAuditEntryId(), e.getMessage(), e);
+
             if (e instanceof IntegrationRestException) {
                 logger.error(((IntegrationRestException) e).getHttpStatusCode() + ":" + ((IntegrationRestException) e).getHttpStatusMessage());
             }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/channel/slack/SlackChannel.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/channel/slack/SlackChannel.java
@@ -83,6 +83,9 @@ public class SlackChannel extends DistributionChannel<SlackEvent, GlobalSlackCon
                 logger.error(((IntegrationRestException) e).getHttpStatusCode() + ":" + ((IntegrationRestException) e).getHttpStatusMessage());
             }
             logger.error(e.getMessage(), e);
+        } catch (final Exception e) {
+            setAuditEntryFailure(event.getAuditEntryId(), e.getMessage(), e);
+            logger.error(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/AuditEntryEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/AuditEntryEntity.java
@@ -33,12 +33,9 @@ import javax.persistence.TemporalType;
 import com.blackducksoftware.integration.hub.alert.enumeration.StatusEnum;
 
 @Entity
-@Table(schema = "alert", name = "audit_entries")
+@Table(schema = "alert", name = "audit_entry")
 public class AuditEntryEntity extends DatabaseEntity {
     private static final long serialVersionUID = -5848616198072005794L;
-
-    @Column(name = "notification_id")
-    private Long notificationId;
 
     @Column(name = "common_config_id")
     private Long commonConfigId;
@@ -64,8 +61,7 @@ public class AuditEntryEntity extends DatabaseEntity {
 
     }
 
-    public AuditEntryEntity(final Long notificationId, final Long commonConfigId, final Date timeCreated, final Date timeLastSent, final StatusEnum status, final String errorMessage, final String errorStackTrace) {
-        this.notificationId = notificationId;
+    public AuditEntryEntity(final Long commonConfigId, final Date timeCreated, final Date timeLastSent, final StatusEnum status, final String errorMessage, final String errorStackTrace) {
         this.commonConfigId = commonConfigId;
         this.timeCreated = timeCreated;
         this.timeLastSent = timeLastSent;
@@ -76,10 +72,6 @@ public class AuditEntryEntity extends DatabaseEntity {
 
     public static long getSerialversionuid() {
         return serialVersionUID;
-    }
-
-    public Long getNotificationId() {
-        return notificationId;
     }
 
     public Long getCommonConfigId() {
@@ -104,6 +96,22 @@ public class AuditEntryEntity extends DatabaseEntity {
 
     public String getErrorStackTrace() {
         return errorStackTrace;
+    }
+
+    public void setTimeLastSent(final Date timeLastSent) {
+        this.timeLastSent = timeLastSent;
+    }
+
+    public void setStatus(final StatusEnum status) {
+        this.status = status;
+    }
+
+    public void setErrorMessage(final String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public void setErrorStackTrace(final String errorStackTrace) {
+        this.errorStackTrace = errorStackTrace;
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/AuditEntryEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/AuditEntryEntity.java
@@ -33,7 +33,7 @@ import javax.persistence.TemporalType;
 import com.blackducksoftware.integration.hub.alert.enumeration.StatusEnum;
 
 @Entity
-@Table(schema = "alert", name = "audit_entry")
+@Table(schema = "alert", name = "audit_entries")
 public class AuditEntryEntity extends DatabaseEntity {
     private static final long serialVersionUID = -5848616198072005794L;
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/AuditEntryEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/AuditEntryEntity.java
@@ -26,9 +26,12 @@ import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Lob;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.Type;
 
 import com.blackducksoftware.integration.hub.alert.enumeration.StatusEnum;
 
@@ -54,7 +57,9 @@ public class AuditEntryEntity extends DatabaseEntity {
     @Column(name = "error_message")
     private String errorMessage;
 
-    @Column(name = "error_stack_trace")
+    @Lob
+    @Type(type = "org.hibernate.type.TextType")
+    @Column(name = "error_stack_trace", length = 10000)
     private String errorStackTrace;
 
     public AuditEntryEntity() {

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/CommonDistributionConfigEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/CommonDistributionConfigEntity.java
@@ -50,7 +50,6 @@ public class CommonDistributionConfigEntity extends DatabaseEntity {
     }
 
     public CommonDistributionConfigEntity(final Long distributionConfigId, final String distributionType, final String name, final String frequency, final Boolean filterByProject) {
-        super();
         this.distributionConfigId = distributionConfigId;
         this.distributionType = distributionType;
         this.name = name;

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/ConfiguredProjectEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/ConfiguredProjectEntity.java
@@ -38,7 +38,6 @@ public class ConfiguredProjectEntity extends DatabaseEntity {
     }
 
     public ConfiguredProjectEntity(final String projectName) {
-        super();
         this.projectName = projectName;
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/distribution/EmailGroupDistributionConfigEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/distribution/EmailGroupDistributionConfigEntity.java
@@ -38,7 +38,6 @@ public class EmailGroupDistributionConfigEntity extends DistributionChannelConfi
     }
 
     public EmailGroupDistributionConfigEntity(final String groupName) {
-        super();
         this.groupName = groupName;
     }
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/distribution/HipChatDistributionConfigEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/distribution/HipChatDistributionConfigEntity.java
@@ -44,7 +44,6 @@ public class HipChatDistributionConfigEntity extends DistributionChannelConfigEn
     }
 
     public HipChatDistributionConfigEntity(final Integer roomId, final Boolean notify, final String color) {
-        super();
         this.roomId = roomId;
         this.notify = notify;
         this.color = color;

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/distribution/SlackDistributionConfigEntity.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/distribution/SlackDistributionConfigEntity.java
@@ -44,7 +44,6 @@ public class SlackDistributionConfigEntity extends DistributionChannelConfigEnti
     }
 
     public SlackDistributionConfigEntity(final String webhook, final String channelUsername, final String channelName) {
-        super();
         this.webhook = webhook;
         this.channelUsername = channelUsername;
         this.channelName = channelName;

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/AuditEntryRepository.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/AuditEntryRepository.java
@@ -22,8 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.alert.datasource.entity.repository;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.blackducksoftware.integration.hub.alert.datasource.entity.AuditEntryEntity;
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/NotificationRepository.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/NotificationRepository.java
@@ -25,9 +25,10 @@ package com.blackducksoftware.integration.hub.alert.datasource.entity.repository
 import java.util.Date;
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.blackducksoftware.integration.hub.alert.datasource.entity.NotificationEntity;
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/global/GlobalHipChatRepository.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/global/GlobalHipChatRepository.java
@@ -22,8 +22,9 @@
  */
 package com.blackducksoftware.integration.hub.alert.datasource.entity.repository.global;
 
+import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.blackducksoftware.integration.hub.alert.datasource.entity.global.GlobalHipChatConfigEntity;
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/relation/AuditNotificationRelation.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/relation/AuditNotificationRelation.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2017 Black Duck Software, Inc.
+ * http://www.blackducksoftware.com/
+ *
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.blackducksoftware.integration.hub.alert.datasource.relation;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.Table;
+
+import com.blackducksoftware.integration.hub.alert.datasource.relation.key.AuditNotificationRelationPK;
+
+@Entity
+@IdClass(AuditNotificationRelationPK.class)
+@Table(schema = "alert", name = "audit_notification_relation")
+public class AuditNotificationRelation extends DatabaseRelation {
+    private static final long serialVersionUID = -6168171736942951164L;
+
+    @Id
+    @Column(name = "audit_entry_id")
+    private Long auditEntryId;
+
+    @Id
+    @Column(name = "notification_id")
+    private Long notificationId;
+
+    public AuditNotificationRelation() {
+    }
+
+    public AuditNotificationRelation(final Long auditEntryId, final Long notificationId) {
+        super();
+        this.auditEntryId = auditEntryId;
+        this.notificationId = notificationId;
+    }
+
+    public static long getSerialversionuid() {
+        return serialVersionUID;
+    }
+
+    public Long getAuditEntryId() {
+        return auditEntryId;
+    }
+
+    public Long getNotificationId() {
+        return notificationId;
+    }
+
+}

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/relation/key/AuditNotificationRelationPK.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/relation/key/AuditNotificationRelationPK.java
@@ -20,15 +20,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.blackducksoftware.integration.hub.alert.datasource.entity.repository;
+package com.blackducksoftware.integration.hub.alert.datasource.relation.key;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
+import java.io.Serializable;
 
-import com.blackducksoftware.integration.hub.alert.datasource.entity.AuditEntryEntity;
+public class AuditNotificationRelationPK implements Serializable {
+    private static final long serialVersionUID = -7710698140802321977L;
 
-@Transactional
-public interface AuditEntryRepository extends JpaRepository<AuditEntryEntity, Long> {
-    public AuditEntryEntity findFirstByCommonConfigIdOrderByTimeLastSentDesc(final Long commonConfigId);
+    public Long auditEntryId;
+    public Long notificationId;
 
+    public AuditNotificationRelationPK() {
+    }
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/relation/repository/AuditNotificationRepository.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/datasource/relation/repository/AuditNotificationRepository.java
@@ -20,15 +20,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package com.blackducksoftware.integration.hub.alert.datasource.entity.repository;
+package com.blackducksoftware.integration.hub.alert.datasource.relation.repository;
+
+import java.util.List;
+
+import javax.transaction.Transactional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
 
-import com.blackducksoftware.integration.hub.alert.datasource.entity.AuditEntryEntity;
+import com.blackducksoftware.integration.hub.alert.datasource.relation.AuditNotificationRelation;
+import com.blackducksoftware.integration.hub.alert.datasource.relation.key.AuditNotificationRelationPK;
 
 @Transactional
-public interface AuditEntryRepository extends JpaRepository<AuditEntryEntity, Long> {
-    public AuditEntryEntity findFirstByCommonConfigIdOrderByTimeLastSentDesc(final Long commonConfigId);
+public interface AuditNotificationRepository extends JpaRepository<AuditNotificationRelation, AuditNotificationRelationPK> {
+    public List<AuditNotificationRelation> findByAuditEntryId(final Long auditEntryId);
+
+    public List<AuditNotificationRelation> findByNotificationId(final Long notificationId);
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/digest/filter/NotificationPostProcessor.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/digest/filter/NotificationPostProcessor.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -39,6 +40,7 @@ import com.blackducksoftware.integration.hub.alert.datasource.relation.Distribut
 import com.blackducksoftware.integration.hub.alert.datasource.relation.DistributionProjectRelation;
 import com.blackducksoftware.integration.hub.alert.datasource.relation.repository.DistributionNotificationTypeRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.relation.repository.DistributionProjectRepository;
+import com.blackducksoftware.integration.hub.alert.digest.DigestTypeEnum;
 import com.blackducksoftware.integration.hub.alert.digest.model.ProjectData;
 import com.blackducksoftware.integration.hub.notification.processor.NotificationCategoryEnum;
 
@@ -90,7 +92,12 @@ public class NotificationPostProcessor {
     }
 
     public boolean doFrequenciesMatch(final CommonDistributionConfigEntity commonDistributionConfigEntity, final ProjectData projectData) {
-        return commonDistributionConfigEntity.getFrequency().equals(projectData.getDigestType().name());
+        final DigestTypeEnum digestTypeEnum = projectData.getDigestType();
+        final String digestName = digestTypeEnum.name();
+        if (StringUtils.isNotBlank(commonDistributionConfigEntity.getFrequency())) {
+            return commonDistributionConfigEntity.getFrequency().equals(digestName);
+        }
+        return false;
     }
 
     public boolean doNotificationTypesMatch(final CommonDistributionConfigEntity commonDistributionConfigEntity, final ProjectData projectData) {

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectData.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectData.java
@@ -22,6 +22,7 @@
  */
 package com.blackducksoftware.integration.hub.alert.digest.model;
 
+import java.util.List;
 import java.util.Map;
 
 import com.blackducksoftware.integration.hub.alert.digest.DigestTypeEnum;
@@ -32,12 +33,14 @@ public class ProjectData extends DigestData {
     private final String projectKey;
     private final String projectName;
     private final String projectVersion;
+    private final List<Long> notificationIds;
     private final Map<NotificationCategoryEnum, CategoryData> categoryMap;
 
-    public ProjectData(final DigestTypeEnum digestType, final String projectName, final String projectVersion, final Map<NotificationCategoryEnum, CategoryData> categoryMap) {
+    public ProjectData(final DigestTypeEnum digestType, final String projectName, final String projectVersion, final List<Long> notificationIds, final Map<NotificationCategoryEnum, CategoryData> categoryMap) {
         this.digestType = digestType;
         this.projectName = projectName;
         this.projectVersion = projectVersion;
+        this.notificationIds = notificationIds;
         this.categoryMap = categoryMap;
         if (projectName != null && projectVersion != null) {
             this.projectKey = projectName + projectVersion;
@@ -62,6 +65,10 @@ public class ProjectData extends DigestData {
 
     public String getProjectVersion() {
         return projectVersion;
+    }
+
+    public List<Long> getNotificationIds() {
+        return notificationIds;
     }
 
     public Map<NotificationCategoryEnum, CategoryData> getCategoryMap() {

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataBuilder.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataBuilder.java
@@ -22,6 +22,8 @@
  */
 package com.blackducksoftware.integration.hub.alert.digest.model;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -33,10 +35,17 @@ public class ProjectDataBuilder {
     private String projectName;
     private String projectVersion;
 
+    private final List<Long> notificationIds;
+
     private final Map<NotificationCategoryEnum, CategoryDataBuilder> categoryBuilderMap;
 
     public ProjectDataBuilder() {
+        notificationIds = new ArrayList<>();
         categoryBuilderMap = new TreeMap<>();
+    }
+
+    public void addNotificationId(final Long notificationId) {
+        notificationIds.add(notificationId);
     }
 
     public void addCategoryBuilder(final NotificationCategoryEnum category, final CategoryDataBuilder categoryBuilder) {
@@ -80,6 +89,6 @@ public class ProjectDataBuilder {
         for (final Map.Entry<NotificationCategoryEnum, CategoryDataBuilder> entry : categoryBuilderMap.entrySet()) {
             categoryMap.put(entry.getKey(), entry.getValue().build());
         }
-        return new ProjectData(digestType, projectName, projectVersion, categoryMap);
+        return new ProjectData(digestType, projectName, projectVersion, notificationIds, categoryMap);
     }
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataFactory.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataFactory.java
@@ -59,6 +59,7 @@ public class ProjectDataFactory {
                 projectBuilder = getProjectDataBuilder(entity, digestType);
                 projectDataMap.put(projectKey, projectBuilder);
             }
+            projectBuilder.addNotificationId(entity.getId());
             final CategoryDataBuilder categoryDataBuilder = getCategoryDataBuilder(entity, projectBuilder.getCategoryBuilderMap());
             addCategoryData(entity, categoryDataBuilder);
         }
@@ -71,6 +72,7 @@ public class ProjectDataFactory {
 
     public ProjectData createProjectData(final NotificationEntity notification, final DigestTypeEnum digestType) {
         final ProjectDataBuilder projectBuilder = getProjectDataBuilder(notification, digestType);
+        projectBuilder.addNotificationId(notification.getId());
         final CategoryDataBuilder categoryData = new CategoryDataBuilder();
         categoryData.setCategoryKey(getCategoryKey(notification).name());
         addCategoryData(notification, categoryData);

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/event/AbstractChannelEvent.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/event/AbstractChannelEvent.java
@@ -28,6 +28,8 @@ public abstract class AbstractChannelEvent extends AbstractEvent {
     private final ProjectData projectData;
     private final Long commonDistributionConfigId;
 
+    private Long auditEntryId;
+
     public AbstractChannelEvent(final ProjectData projectData, final Long commonDistributionConfigId) {
         super();
         this.projectData = projectData;
@@ -40,6 +42,14 @@ public abstract class AbstractChannelEvent extends AbstractEvent {
 
     public Long getCommonDistributionConfigId() {
         return commonDistributionConfigId;
+    }
+
+    public Long getAuditEntryId() {
+        return auditEntryId;
+    }
+
+    public void setAuditEntryId(final Long auditEntryId) {
+        this.auditEntryId = auditEntryId;
     }
 
 }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/AuditEntryActions.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/AuditEntryActions.java
@@ -103,7 +103,7 @@ public class AuditEntryActions {
             final List<NotificationEntity> notifications = notificationRepository.findAll(notificationIds);
             final Long commonConfigId = auditEntryEntity.getCommonConfigId();
             final CommonDistributionConfigEntity commonConfigEntity = commonDistributionRepository.findOne(commonConfigId);
-            if (notifications != null && commonConfigEntity != null) {
+            if (notifications != null && !notifications.isEmpty() && commonConfigEntity != null) {
                 final Collection<ProjectData> projectDataList = projectDataFactory.createProjectDataCollection(notifications);
                 for (final ProjectData projectData : projectDataList) {
                     final AbstractChannelEvent event = channelEventFactory.createEvent(commonConfigId, commonConfigEntity.getDistributionType(), projectData);

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/AuditEntryActions.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/AuditEntryActions.java
@@ -107,6 +107,7 @@ public class AuditEntryActions {
                 final Collection<ProjectData> projectDataList = projectDataFactory.createProjectDataCollection(notifications);
                 for (final ProjectData projectData : projectDataList) {
                     final AbstractChannelEvent event = channelEventFactory.createEvent(commonConfigId, commonConfigEntity.getDistributionType(), projectData);
+                    event.setAuditEntryId(auditEntryEntity.getId());
                     channelTemplateManager.sendEvent(event);
                 }
                 return auditEntryEntity;
@@ -137,7 +138,11 @@ public class AuditEntryActions {
         final String timeCreated = objectTransformer.objectToString(auditEntryEntity.getTimeCreated());
         final String timeLastSent = objectTransformer.objectToString(auditEntryEntity.getTimeLastSent());
 
-        final String status = auditEntryEntity.getStatus().getDisplayName();
+        String status = null;
+        if (auditEntryEntity.getStatus() != null) {
+            status = auditEntryEntity.getStatus().getDisplayName();
+        }
+
         final String errorMessage = auditEntryEntity.getErrorMessage();
         final String errorStackTrace = auditEntryEntity.getErrorStackTrace();
 

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/AuditEntryActions.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/AuditEntryActions.java
@@ -23,7 +23,9 @@
 package com.blackducksoftware.integration.hub.alert.web.actions;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +42,8 @@ import com.blackducksoftware.integration.hub.alert.datasource.entity.global.Glob
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.NotificationRepository;
+import com.blackducksoftware.integration.hub.alert.datasource.relation.AuditNotificationRelation;
+import com.blackducksoftware.integration.hub.alert.datasource.relation.repository.AuditNotificationRepository;
 import com.blackducksoftware.integration.hub.alert.digest.model.ProjectData;
 import com.blackducksoftware.integration.hub.alert.digest.model.ProjectDataFactory;
 import com.blackducksoftware.integration.hub.alert.event.AbstractChannelEvent;
@@ -55,6 +59,7 @@ public class AuditEntryActions {
 
     private final AuditEntryRepository auditEntryRepository;
     private final NotificationRepository notificationRepository;
+    private final AuditNotificationRepository auditNotificationRepository;
     private final CommonDistributionRepository commonDistributionRepository;
     private final ObjectTransformer objectTransformer;
     private final ChannelEventFactory<AbstractChannelEvent, DistributionChannelConfigEntity, GlobalChannelConfigEntity, CommonDistributionConfigRestModel> channelEventFactory;
@@ -62,11 +67,13 @@ public class AuditEntryActions {
     private final ChannelTemplateManager channelTemplateManager;
 
     @Autowired
-    public AuditEntryActions(final AuditEntryRepository auditEntryRepository, final NotificationRepository notificationRepository, final CommonDistributionRepository commonDistributionRepository, final ObjectTransformer objectTransformer,
+    public AuditEntryActions(final AuditEntryRepository auditEntryRepository, final NotificationRepository notificationRepository, final AuditNotificationRepository auditNotificationRepository,
+            final CommonDistributionRepository commonDistributionRepository, final ObjectTransformer objectTransformer,
             final ChannelEventFactory<AbstractChannelEvent, DistributionChannelConfigEntity, GlobalChannelConfigEntity, CommonDistributionConfigRestModel> channelEventFactory, final ProjectDataFactory projectDataFactory,
             final ChannelTemplateManager channelTemplateManager) {
         this.auditEntryRepository = auditEntryRepository;
         this.notificationRepository = notificationRepository;
+        this.auditNotificationRepository = auditNotificationRepository;
         this.commonDistributionRepository = commonDistributionRepository;
         this.objectTransformer = objectTransformer;
         this.channelEventFactory = channelEventFactory;
@@ -91,13 +98,17 @@ public class AuditEntryActions {
     public AuditEntryEntity resendNotification(final Long id) {
         final AuditEntryEntity auditEntryEntity = auditEntryRepository.findOne(id);
         if (auditEntryEntity != null) {
-            final NotificationEntity notificationEntity = notificationRepository.findOne(auditEntryEntity.getNotificationId());
+            final List<AuditNotificationRelation> relations = auditNotificationRepository.findByAuditEntryId(auditEntryEntity.getId());
+            final List<Long> notificationIds = relations.stream().map(relation -> relation.getNotificationId()).collect(Collectors.toList());
+            final List<NotificationEntity> notifications = notificationRepository.findAll(notificationIds);
             final Long commonConfigId = auditEntryEntity.getCommonConfigId();
             final CommonDistributionConfigEntity commonConfigEntity = commonDistributionRepository.findOne(commonConfigId);
-            if (notificationEntity != null && commonConfigEntity != null) {
-                final ProjectData projectData = projectDataFactory.createProjectData(notificationEntity);
-                final AbstractChannelEvent event = channelEventFactory.createEvent(commonConfigId, commonConfigEntity.getDistributionType(), projectData);
-                channelTemplateManager.sendEvent(event);
+            if (notifications != null && commonConfigEntity != null) {
+                final Collection<ProjectData> projectDataList = projectDataFactory.createProjectDataCollection(notifications);
+                for (final ProjectData projectData : projectDataList) {
+                    final AbstractChannelEvent event = channelEventFactory.createEvent(commonConfigId, commonConfigEntity.getDistributionType(), projectData);
+                    channelTemplateManager.sendEvent(event);
+                }
                 return auditEntryEntity;
             }
             throw new IllegalArgumentException("The notification for this entry was purged. To edit the purge schedule, please see the Scheduling Configuration.");
@@ -114,10 +125,12 @@ public class AuditEntryActions {
     }
 
     private AuditEntryRestModel createRestModel(final AuditEntryEntity auditEntryEntity) {
-        final Long notificationId = auditEntryEntity.getNotificationId();
         final Long commonConfigId = auditEntryEntity.getCommonConfigId();
 
-        final NotificationEntity notificationEntity = notificationRepository.findOne(notificationId);
+        final List<AuditNotificationRelation> relations = auditNotificationRepository.findByAuditEntryId(auditEntryEntity.getId());
+        final List<Long> notificationIds = relations.stream().map(relation -> relation.getNotificationId()).collect(Collectors.toList());
+        final List<NotificationEntity> notifications = notificationRepository.findAll(notificationIds);
+
         final CommonDistributionConfigEntity commonConfigEntity = commonDistributionRepository.findOne(commonConfigId);
 
         final String id = objectTransformer.objectToString(auditEntryEntity.getId());
@@ -129,13 +142,16 @@ public class AuditEntryActions {
         final String errorStackTrace = auditEntryEntity.getErrorStackTrace();
 
         NotificationRestModel notificationRestModel = null;
-        if (notificationEntity != null) {
+        if (!notifications.isEmpty() && notifications.get(0) != null) {
             try {
-                notificationRestModel = objectTransformer.databaseEntityToConfigRestModel(notificationEntity, NotificationRestModel.class);
+                // TODO check to see the notificationTypes field does not mess up the conversion
+                notificationRestModel = objectTransformer.databaseEntityToConfigRestModel(notifications.get(0), NotificationRestModel.class);
             } catch (final AlertException e) {
                 logger.error("Problem converting audit entry with id {}: {}", auditEntryEntity.getId(), e.getMessage());
             }
         }
+        final List<String> notificationTypes = notifications.stream().map(notification -> notification.getNotificationType()).collect(Collectors.toList());
+        notificationRestModel.setNotificationTypes(notificationTypes);
 
         String distributionConfigName = null;
         String eventType = null;

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/EmailGroupDistributionConfigActions.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/EmailGroupDistributionConfigActions.java
@@ -23,7 +23,6 @@
 package com.blackducksoftware.integration.hub.alert.web.actions.distribution;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
@@ -32,6 +31,7 @@ import com.blackducksoftware.integration.hub.alert.channel.email.EmailGroupManag
 import com.blackducksoftware.integration.hub.alert.datasource.entity.CommonDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.EmailGroupDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.EmailGroupDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.exception.AlertException;
 import com.blackducksoftware.integration.hub.alert.web.ObjectTransformer;
 import com.blackducksoftware.integration.hub.alert.web.actions.ConfiguredProjectsActions;
@@ -43,7 +43,7 @@ public class EmailGroupDistributionConfigActions extends DistributionConfigActio
     private final EmailGroupManager emailManager;
 
     @Autowired
-    public EmailGroupDistributionConfigActions(final CommonDistributionRepository commonDistributionRepository, final JpaRepository<EmailGroupDistributionConfigEntity, Long> repository,
+    public EmailGroupDistributionConfigActions(final CommonDistributionRepository commonDistributionRepository, final EmailGroupDistributionRepository repository,
             final ConfiguredProjectsActions<EmailGroupDistributionRestModel> configuredProjectsActions, final NotificationTypesActions<EmailGroupDistributionRestModel> notificationTypesActions, final ObjectTransformer objectTransformer,
             final EmailGroupManager emailManager) {
         super(EmailGroupDistributionConfigEntity.class, EmailGroupDistributionRestModel.class, commonDistributionRepository, repository, configuredProjectsActions, notificationTypesActions, objectTransformer);

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/HipChatDistributionConfigActions.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/HipChatDistributionConfigActions.java
@@ -23,7 +23,6 @@
 package com.blackducksoftware.integration.hub.alert.web.actions.distribution;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
@@ -32,6 +31,7 @@ import com.blackducksoftware.integration.hub.alert.channel.hipchat.HipChatManage
 import com.blackducksoftware.integration.hub.alert.datasource.entity.CommonDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.HipChatDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.HipChatDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.exception.AlertException;
 import com.blackducksoftware.integration.hub.alert.web.ObjectTransformer;
 import com.blackducksoftware.integration.hub.alert.web.actions.ConfiguredProjectsActions;
@@ -43,7 +43,7 @@ public class HipChatDistributionConfigActions extends DistributionConfigActions<
     private final HipChatManager hipChatManager;
 
     @Autowired
-    public HipChatDistributionConfigActions(final CommonDistributionRepository commonDistributionRepository, final JpaRepository<HipChatDistributionConfigEntity, Long> channelDistributionRepository,
+    public HipChatDistributionConfigActions(final CommonDistributionRepository commonDistributionRepository, final HipChatDistributionRepository channelDistributionRepository,
             final ConfiguredProjectsActions<HipChatDistributionRestModel> configuredProjectsActions, final NotificationTypesActions<HipChatDistributionRestModel> notificationTypesActions, final ObjectTransformer objectTransformer,
             final HipChatManager hipChatManager) {
         super(HipChatDistributionConfigEntity.class, HipChatDistributionRestModel.class, commonDistributionRepository, channelDistributionRepository, configuredProjectsActions, notificationTypesActions, objectTransformer);

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/SlackDistributionConfigActions.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/SlackDistributionConfigActions.java
@@ -23,7 +23,6 @@
 package com.blackducksoftware.integration.hub.alert.web.actions.distribution;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Component;
 
 import com.blackducksoftware.integration.exception.IntegrationException;
@@ -32,6 +31,7 @@ import com.blackducksoftware.integration.hub.alert.channel.slack.SlackManager;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.CommonDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.SlackDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.SlackDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.exception.AlertException;
 import com.blackducksoftware.integration.hub.alert.web.ObjectTransformer;
 import com.blackducksoftware.integration.hub.alert.web.actions.ConfiguredProjectsActions;
@@ -43,9 +43,8 @@ public class SlackDistributionConfigActions extends DistributionConfigActions<Sl
     private final SlackManager slackManager;
 
     @Autowired
-    public SlackDistributionConfigActions(final CommonDistributionRepository commonDistributionRepository, final JpaRepository<SlackDistributionConfigEntity, Long> repository,
-            final ConfiguredProjectsActions<SlackDistributionRestModel> configuredProjectsActions, final NotificationTypesActions<SlackDistributionRestModel> notificationTypesActions, final ObjectTransformer objectTransformer,
-            final SlackManager slackManager) {
+    public SlackDistributionConfigActions(final CommonDistributionRepository commonDistributionRepository, final SlackDistributionRepository repository, final ConfiguredProjectsActions<SlackDistributionRestModel> configuredProjectsActions,
+            final NotificationTypesActions<SlackDistributionRestModel> notificationTypesActions, final ObjectTransformer objectTransformer, final SlackManager slackManager) {
         super(SlackDistributionConfigEntity.class, SlackDistributionRestModel.class, commonDistributionRepository, repository, configuredProjectsActions, notificationTypesActions, objectTransformer);
         this.slackManager = slackManager;
     }

--- a/src/main/java/com/blackducksoftware/integration/hub/alert/web/model/NotificationRestModel.java
+++ b/src/main/java/com/blackducksoftware/integration/hub/alert/web/model/NotificationRestModel.java
@@ -22,6 +22,8 @@
  */
 package com.blackducksoftware.integration.hub.alert.web.model;
 
+import java.util.List;
+
 import org.apache.commons.lang3.builder.RecursiveToStringStyle;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 
@@ -30,7 +32,7 @@ public class NotificationRestModel extends ConfigRestModel {
 
     private String eventKey;
     private String createdAt;
-    private String notificationType;
+    private List<String> notificationTypes;
     private String projectName;
     private String projectVersion;
     private String componentName;
@@ -43,12 +45,12 @@ public class NotificationRestModel extends ConfigRestModel {
     public NotificationRestModel() {
     }
 
-    public NotificationRestModel(final String id, final String eventKey, final String createdAt, final String notificationType, final String projectName, final String projectVersion, final String componentName,
+    public NotificationRestModel(final String id, final String eventKey, final String createdAt, final List<String> notificationTypes, final String projectName, final String projectVersion, final String componentName,
             final String componentVersion, final String policyRuleName, final String person, final String projectUrl, final String projectVersionUrl) {
         super(id);
         this.eventKey = eventKey;
         this.createdAt = createdAt;
-        this.notificationType = notificationType;
+        this.notificationTypes = notificationTypes;
         this.projectName = projectName;
         this.projectVersion = projectVersion;
         this.componentName = componentName;
@@ -71,8 +73,12 @@ public class NotificationRestModel extends ConfigRestModel {
         return createdAt;
     }
 
-    public String getNotificationType() {
-        return notificationType;
+    public List<String> getNotificationTypes() {
+        return notificationTypes;
+    }
+
+    public void setNotificationTypes(final List<String> notificationTypes) {
+        this.notificationTypes = notificationTypes;
     }
 
     public String getProjectName() {
@@ -109,7 +115,14 @@ public class NotificationRestModel extends ConfigRestModel {
 
     @Override
     public String toString() {
+        String[] notificationTypesToStringArray = null;
+        if (notificationTypes != null) {
+            notificationTypesToStringArray = notificationTypes.toArray(new String[notificationTypes.size()]);
+        }
+
         final ReflectionToStringBuilder reflectionToStringBuilder = new ReflectionToStringBuilder(this, RecursiveToStringStyle.JSON_STYLE);
+        reflectionToStringBuilder.setExcludeFieldNames("notificationTypes");
+        reflectionToStringBuilder.append("notificationTypes", notificationTypesToStringArray);
         return reflectionToStringBuilder.build();
     }
 

--- a/src/main/js/component/audit/Audit.js
+++ b/src/main/js/component/audit/Audit.js
@@ -19,7 +19,7 @@ class Audit extends Component {
 			entries: [],
 			modal: undefined
 		};
-		this.addDefaultEntries = this.addDefaultEntries.bind(this);
+		// this.addDefaultEntries = this.addDefaultEntries.bind(this);
         this.handleSetState = this.handleSetState.bind(this);
         this.resendButton = this.resendButton.bind(this);
         this.onResendClick = this.onResendClick.bind(this);
@@ -63,13 +63,18 @@ class Audit extends Component {
 	}
 
 	componentDidMount() {
+		this.reloadAuditEntries();
+
+		// this.addDefaultEntries();
+	}
+
+	reloadAuditEntries(){
 		var self = this;
 		fetch('/audit',{
 			credentials: "same-origin"
 		})
 		.then(function(response) {
 			self.handleSetState('inProgress', false);
-			self.handleSetState('waitingForProjects', false);
 			if (!response.ok) {
 				return response.json().then(json => {
 					self.handleSetState('message', json.message);
@@ -78,7 +83,7 @@ class Audit extends Component {
 				return response.json().then(jsonArray => {
 					self.handleSetState('message', '');
 					if (jsonArray != null && jsonArray.length > 0) {
-						var entries = self.state.entries;
+						var entries = [];
 						for (var index in jsonArray) {
 							var newEntry = {};
 							newEntry.id = jsonArray[index].id;
@@ -90,7 +95,7 @@ class Audit extends Component {
 				            newEntry.errorMessage =  jsonArray[index].errorMessage;
 				            newEntry.errorStackTrace = jsonArray[index].errorStackTrace;
 							if (jsonArray[index].notification) {
-					            newEntry.notificationTypes = jsonArray[index].notification.notificationTypes;
+								newEntry.notificationTypes = jsonArray[index].notification.notificationTypes;
 					            newEntry.notificationProjectName = jsonArray[index].notification.projectName;
 								newEntry.notificationProjectVersion = jsonArray[index].notification.projectVersion;
 								newEntry.notificationComponentName = jsonArray[index].notification.componentName;
@@ -106,9 +111,9 @@ class Audit extends Component {
 				});
 			}
 		});
-
-		// this.addDefaultEntries();
 	}
+
+
 
 	handleSetState(name, value) {
 		this.setState({
@@ -123,12 +128,29 @@ class Audit extends Component {
 	}
 
 	onResendClick(currentRowSelected){
-		console.log(currentRowSelected);
 		var currentEntry = currentRowSelected;
 		if (!currentRowSelected){
 			currentEntry = this.state.currentRowSelected;
 		}
-		console.log(currentEntry);
+
+		var self = this;		
+		var resendUrl = '/audit/' + currentEntry.id + '/resend';
+		fetch(resendUrl, {
+			method: 'POST',
+			credentials: "same-origin",
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		}).then(function(response) {
+			self.handleSetState('inProgress', false);
+			var response = response.json().then(json => {
+				self.handleSetState('message', json.message);
+			});
+
+			self.reloadAuditEntries();
+
+			return response;
+		});
 	}
 
 	resendButton(cell, row) {
@@ -173,6 +195,35 @@ class Audit extends Component {
 		return data;
 	}
 
+	notificationTypeDataFormat(cell, row) {
+		if (cell && cell.length > 0) {
+			let cellText = '';
+			for (var i in cell) {
+				if (cell[i] === "POLICY_VIOLATION") {
+					cellText = cellText + " PV";
+				} else if (cell[i] === "POLICY_VIOLATION_CLEARED") {
+					cellText = cellText + " PVC";
+				} else if (cell[i] === "POLICY_VIOLATION_OVERRIDE") {
+					cellText = cellText + " PVO";
+				} else if (cell[i] === "HIGH_VULNERABILITY") {
+					cellText = cellText + " HV";
+				} else if (cell[i] === "MEDIUM_VULNERABILITY") {
+					cellText = cellText + " MV";
+				} else if (cell[i] === "LOW_VULNERABILITY") {
+					cellText = cellText + " LV";
+				} else if (cell[i] === "VULNERABILITY") {
+					cellText = cellText + " V";
+				}
+			}
+			cellText = cellText.trim();			
+			let data = <div>
+						{cellText}
+					</div>;
+			return data;
+		}
+		return null;
+	}
+
 	isExpandableRow(row) {
     	return true;
   	}
@@ -202,7 +253,7 @@ class Audit extends Component {
 	      					<TableHeaderColumn dataField='id' isKey hidden>Audit Id</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='jobName' dataSort columnClassName={tableStyles.tableCell}>Distribution Job</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='eventType' dataSort columnClassName={tableStyles.tableCell} dataFormat={ this.typeColumnDataFormat }>Event Type</TableHeaderColumn>
-	      					<TableHeaderColumn dataField='notificationType' dataSort columnClassName={tableStyles.tableCell}>Notification Type</TableHeaderColumn>
+	      					<TableHeaderColumn dataField='notificationTypes' dataSort columnClassName={tableStyles.tableCell} dataFormat={ this.notificationTypeDataFormat }>Notification Types</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='timeCreated' dataSort columnClassName={tableStyles.tableCell}>Time Created</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='timeLastSent' dataSort columnClassName={tableStyles.tableCell}>Time Last Sent</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='status' dataSort columnClassName={tableStyles.tableCell} dataFormat={ this.statusColumnDataFormat }>Status</TableHeaderColumn>

--- a/src/main/js/component/audit/Audit.js
+++ b/src/main/js/component/audit/Audit.js
@@ -28,32 +28,32 @@ class Audit extends Component {
         this.statusColumnDataFormat = this.statusColumnDataFormat.bind(this);
 	}
 
-	addDefaultEntries() {
-        const { entries } = this.state;
-        entries.push({
-            id: '999',
-            jobName: 'Test Job',
-            eventType: 'email_group_channel',
-            notificationType: 'High Vulnerability',
-            timeCreated: '12/01/2017 00:00:00',
-            timeLastSent: '12/01/2017 00:00:00',
-            status: 'Success'
-        });
-        entries.push({
-            id: '111',
-            jobName: 'Test Hipchat',
-            eventType: 'hipchat_channel',
-            notificationType: 'High Vulnerability',
-            timeCreated: '12/01/2017 00:00:00',
-            timeLastSent: '12/01/2017 00:00:00',
-            status: 'Failure',
-            errorMessage: 'Could not reach Hipchat',
-            errorStackTrace: 'Exception : could not reach hipchat \n at someClass(line:55) \n at someClass(line:55) \n at someClass(line:55) \n at someClass(line:55) \n at someClass(line:55)'
-        });
-        this.setState({
-			entries
-		});
-    }
+	// addDefaultEntries() {
+ //        const { entries } = this.state;
+ //        entries.push({
+ //            id: '999',
+ //            jobName: 'Test Job',
+ //            eventType: 'email_group_channel',
+ //            notificationType: 'High Vulnerability',
+ //            timeCreated: '12/01/2017 00:00:00',
+ //            timeLastSent: '12/01/2017 00:00:00',
+ //            status: 'Success'
+ //        });
+ //        entries.push({
+ //            id: '111',
+ //            jobName: 'Test Hipchat',
+ //            eventType: 'hipchat_channel',
+ //            notificationType: 'High Vulnerability',
+ //            timeCreated: '12/01/2017 00:00:00',
+ //            timeLastSent: '12/01/2017 00:00:00',
+ //            status: 'Failure',
+ //            errorMessage: 'Could not reach Hipchat',
+ //            errorStackTrace: 'Exception : could not reach hipchat \n at someClass(line:55) \n at someClass(line:55) \n at someClass(line:55) \n at someClass(line:55) \n at someClass(line:55)'
+ //        });
+ //        this.setState({
+	// 		entries
+	// 	});
+ //    }
 
     componentWillMount() {
 		this.setState({
@@ -78,36 +78,36 @@ class Audit extends Component {
 				return response.json().then(jsonArray => {
 					self.handleSetState('message', '');
 					if (jsonArray != null && jsonArray.length > 0) {
-						var projects = [];
+						var entries = self.state.entries;
 						for (var index in jsonArray) {
-							var newProject = {};
-							newProject.id = jsonArray[index].id;
-				            newProject.jobName = jsonArray[index].name;
-				            newProject.eventType = jsonArray[index].eventType;
-				            newProject.timeCreated = jsonArray[index].timeCreated;
-				            newProject.timeLastSent = jsonArray[index].timeLastSent;
-				            newProject.status =  jsonArray[index].status;
-				            newProject.errorMessage =  jsonArray[index].errorMessage;
-				            newProject.errorStackTrace = jsonArray[index].errorStackTrace;
+							var newEntry = {};
+							newEntry.id = jsonArray[index].id;
+				            newEntry.jobName = jsonArray[index].name;
+				            newEntry.eventType = jsonArray[index].eventType;
+				            newEntry.timeCreated = jsonArray[index].timeCreated;
+				            newEntry.timeLastSent = jsonArray[index].timeLastSent;
+				            newEntry.status =  jsonArray[index].status;
+				            newEntry.errorMessage =  jsonArray[index].errorMessage;
+				            newEntry.errorStackTrace = jsonArray[index].errorStackTrace;
 							if (jsonArray[index].notification) {
-					            newProject.notificationType = jsonArray[index].notification.notificationType;
-					            newProject.notificationProjectName = jsonArray[index].notification.projectName;
-								newProject.notificationProjectVersion = jsonArray[index].notification.projectVersion;
-								newProject.notificationComponentName = jsonArray[index].notification.componentName;
-								newProject.notificationComponentVersion = jsonArray[index].notification.componentVersion;
-								newProject.notificationPolicyRuleName = jsonArray[index].notification.policyRuleName;
+					            newEntry.notificationTypes = jsonArray[index].notification.notificationTypes;
+					            newEntry.notificationProjectName = jsonArray[index].notification.projectName;
+								newEntry.notificationProjectVersion = jsonArray[index].notification.projectVersion;
+								newEntry.notificationComponentName = jsonArray[index].notification.componentName;
+								newEntry.notificationComponentVersion = jsonArray[index].notification.componentVersion;
+								newEntry.notificationPolicyRuleName = jsonArray[index].notification.policyRuleName;
 							}
-							projects.push(newProject);
+							entries.push(newEntry);
 						}
 						self.setState({
-							projects
+							entries
 						});
 					}
 				});
 			}
 		});
 
-		this.addDefaultEntries();
+		// this.addDefaultEntries();
 	}
 
 	handleSetState(name, value) {

--- a/src/main/js/component/audit/Audit.js
+++ b/src/main/js/component/audit/Audit.js
@@ -232,6 +232,15 @@ class Audit extends Component {
 		return <AuditDetails currentEntry={row}/>;
 	}
 
+	trClassFormat(row, rowIndex) {
+		// color the row correctly, since Striped does not work with expandable rows
+		var isEven = rowIndex % 2 === 0;
+		var className = isEven ? tableStyles.tableEvenRow : tableStyles.tableRow; 
+		return className; 
+	}
+
+
+
 	render() {
 		const auditTableOptions = {
 	  		noDataText: 'No events',
@@ -249,7 +258,7 @@ class Audit extends Component {
 		return (
 				<div>
 					<div>
-						<BootstrapTable data={this.state.entries} expandableRow={this.isExpandableRow} expandComponent={this.expandComponent} containerClass={tableStyles.table} striped hover condensed search={true} options={auditTableOptions} headerContainerClass={tableStyles.scrollable} bodyContainerClass={tableStyles.tableScrollableBody} >
+						<BootstrapTable trClassName={this.trClassFormat} hover condensed data={this.state.entries} expandableRow={this.isExpandableRow} expandComponent={this.expandComponent} containerClass={tableStyles.table} search={true} options={auditTableOptions} headerContainerClass={tableStyles.scrollable} bodyContainerClass={tableStyles.tableScrollableBody} >
 	      					<TableHeaderColumn dataField='id' isKey hidden>Audit Id</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='jobName' dataSort columnClassName={tableStyles.tableCell}>Distribution Job</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='eventType' dataSort columnClassName={tableStyles.tableCell} dataFormat={ this.typeColumnDataFormat }>Event Type</TableHeaderColumn>

--- a/src/main/js/component/audit/AuditDetails.js
+++ b/src/main/js/component/audit/AuditDetails.js
@@ -10,6 +10,12 @@ class AuditDetails extends Component {
 		super(props);
 		var currentEntry = props.currentEntry;
 		let values = {};
+		values.notificationProjectName = currentEntry.notificationProjectName;
+		values.notificationProjectVersion = currentEntry.notificationProjectVersion;
+		values.notificationComponentName = currentEntry.notificationComponentName;
+		values.notificationComponentVersion = currentEntry.notificationComponentVersion;
+		values.notificationPolicyRuleName = currentEntry.notificationPolicyRuleName;
+
 		values.errorMessage = currentEntry.errorMessage;
 		values.errorStackTrace = currentEntry.errorStackTrace;
 		this.state = {
@@ -19,6 +25,27 @@ class AuditDetails extends Component {
 	}
 
 	render(content) {
+		var notificationProjectName = null;
+		if (this.state.values.notificationProjectName) {
+			notificationProjectName = <TextInput label="Project Name" readOnly={true} name="notificationProjectName" value={this.state.values.notificationProjectName}></TextInput>;
+		}
+		var notificationProjectVersion = null;
+		if (this.state.values.notificationProjectVersion) {
+			notificationProjectVersion = <TextInput label="Project Version" readOnly={true} name="notificationProjectVersion" value={this.state.values.notificationProjectVersion}></TextInput>;
+		}
+		var notificationComponentName = null;
+		if (this.state.values.notificationComponentName) {
+			notificationComponentName = <TextInput label="Component Name" readOnly={true} name="notificationComponentName" value={this.state.values.notificationComponentName}></TextInput>;
+		}
+		var notificationComponentVersion = null;
+		if (this.state.values.notificationComponentVersion) {
+			notificationComponentVersion = <TextInput label="Component Version" readOnly={true} name="notificationComponentVersion" value={this.state.values.notificationComponentVersion}></TextInput>;
+		}
+		var notificationPolicyRuleName = null;
+		if (this.state.values.notificationPolicyRuleName) {
+			notificationPolicyRuleName = <TextInput label="Policy Rule Name" readOnly={true} name="notificationPolicyRuleName" value={this.state.values.notificationPolicyRuleName}></TextInput>;
+		}
+
 		var errorMessage = null;
 		if (this.state.values.errorMessage) {
 			errorMessage = <TextInput label="Error" readOnly={true} name="errorMessage" value={this.state.values.errorMessage}></TextInput>;
@@ -29,6 +56,11 @@ class AuditDetails extends Component {
 		}
 		return(
 			<div className={tableStyles.expandableContainer}>
+				{notificationProjectName}
+				{notificationProjectVersion}
+				{notificationComponentName}
+				{notificationComponentVersion}
+				{notificationPolicyRuleName}
 				{errorMessage}
 				{errorStackTrace}
 			</div>

--- a/src/main/js/component/distribution/DistributionConfiguration.js
+++ b/src/main/js/component/distribution/DistributionConfiguration.js
@@ -380,7 +380,7 @@ class DistributionConfiguration extends Component {
 			}
 		};
 		var content = <div>
-						<BootstrapTable data={this.state.jobs} containerClass={tableStyles.table} striped hover condensed insertRow={true} deleteRow={true} selectRow={jobsSelectRowProp} search={true} options={jobTableOptions} trClassName={tableStyles.tableRow} headerContainerClass={tableStyles.scrollable} bodyContainerClass={tableStyles.tableScrollableBody} >
+						<BootstrapTable striped hover condensed data={this.state.jobs} containerClass={tableStyles.table} insertRow={true} deleteRow={true} selectRow={jobsSelectRowProp} search={true} options={jobTableOptions} trClassName={tableStyles.tableRow} headerContainerClass={tableStyles.scrollable} bodyContainerClass={tableStyles.tableScrollableBody} >
 	      					<TableHeaderColumn dataField='id' isKey hidden>Job Id</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='distributionConfigId' hidden>Distribution Id</TableHeaderColumn>
 	      					<TableHeaderColumn dataField='name' dataSort columnClassName={tableStyles.tableCell} >Distribution Job</TableHeaderColumn>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,6 +4,7 @@
     	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" />
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
 		<script src="http://code.jquery.com/jquery-3.2.1.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
         <link rel="icon" href="favicon.ico" type="image/x-icon"/>
         <meta charset="UTF-8" />
         <title>Black Duck Alert</title>

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/MockUtils.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/MockUtils.java
@@ -125,8 +125,8 @@ public class MockUtils {
     }
 
     public NotificationEntity createNotificationEntity() {
-        return new NotificationEntity("_event_key_", new Date(), "POLICY_VIOLATION", "Test Project Name", "", "Test Project Version Name", "", "Component Name", "Component Version Name", "Policy Rule Name", "Person",
-                Collections.emptyList());
+        return new NotificationEntity("_event_key_", new Date(System.currentTimeMillis()), "POLICY_VIOLATION", "Test Project Name", "", "Test Project Version Name", "", "Component Name", "Component Version Name", "Policy Rule Name",
+                "Person", Collections.emptyList());
     }
 
 }

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/channel/ChannelTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/channel/ChannelTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 
 import org.junit.After;
@@ -94,7 +95,7 @@ public class ChannelTest {
         categoryMap.put(NotificationCategoryEnum.POLICY_VIOLATION, createMockPolicyViolation());
         categoryMap.put(NotificationCategoryEnum.MEDIUM_VULNERABILITY, createMockVulnerability());
 
-        final ProjectData projectData = new ProjectData(DigestTypeEnum.REAL_TIME, testName, testName + " Version", categoryMap);
+        final ProjectData projectData = new ProjectData(DigestTypeEnum.REAL_TIME, testName, testName + " Version", Collections.emptyList(), categoryMap);
         return projectData;
     }
 

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/channel/email/EmailChannelTestIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/channel/email/EmailChannelTestIT.java
@@ -10,6 +10,7 @@ import com.blackducksoftware.integration.hub.alert.TestPropertyKey;
 import com.blackducksoftware.integration.hub.alert.channel.ChannelTest;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.global.GlobalEmailConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.global.GlobalHubConfigEntity;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.global.GlobalHubRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.global.GlobalSchedulingRepository;
 import com.blackducksoftware.integration.hub.alert.digest.model.ProjectData;
@@ -18,6 +19,7 @@ public class EmailChannelTestIT extends ChannelTest {
 
     @Test
     public void sendEmailTest() throws Exception {
+        final AuditEntryRepository auditEntryRepository = Mockito.mock(AuditEntryRepository.class);
         final GlobalHubRepository globalRepository = Mockito.mock(GlobalHubRepository.class);
         final GlobalHubConfigEntity globalConfig = new GlobalHubConfigEntity(300, properties.getProperty(TestPropertyKey.TEST_USERNAME), properties.getProperty(TestPropertyKey.TEST_PASSWORD));
         Mockito.when(globalRepository.findAll()).thenReturn(Arrays.asList(globalConfig));
@@ -31,7 +33,7 @@ public class EmailChannelTestIT extends ChannelTest {
             globalProperties.setHubTrustCertificate(Boolean.valueOf(trustCert));
         }
 
-        EmailGroupChannel emailChannel = new EmailGroupChannel(globalProperties, gson, null, null, null);
+        EmailGroupChannel emailChannel = new EmailGroupChannel(globalProperties, gson, auditEntryRepository, null, null, null);
         final ProjectData projectData = createProjectData("Manual test project");
         final EmailGroupEvent event = new EmailGroupEvent(projectData, null);
 

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/channel/hipchat/HipChatChannelTestIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/channel/hipchat/HipChatChannelTestIT.java
@@ -23,6 +23,7 @@ import com.blackducksoftware.integration.hub.alert.TestPropertyKey;
 import com.blackducksoftware.integration.hub.alert.channel.ChannelTest;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.HipChatDistributionConfigEntity;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.global.GlobalHipChatConfigEntity;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.global.GlobalHubRepository;
 import com.blackducksoftware.integration.hub.alert.digest.model.ProjectData;
 
@@ -30,9 +31,10 @@ public class HipChatChannelTestIT extends ChannelTest {
 
     @Test
     public void sendMessageTestIT() throws IOException {
+        final AuditEntryRepository auditEntryRepository = Mockito.mock(AuditEntryRepository.class);
         final GlobalHubRepository mockedGlobalRepository = Mockito.mock(GlobalHubRepository.class);
         final TestGlobalProperties globalProperties = new TestGlobalProperties(mockedGlobalRepository, null);
-        HipChatChannel hipChatChannel = new HipChatChannel(gson, globalProperties, null, null, null);
+        HipChatChannel hipChatChannel = new HipChatChannel(gson, auditEntryRepository, globalProperties, null, null, null);
 
         final ProjectData data = createProjectData("Integration test project");
         final HipChatEvent event = new HipChatEvent(data, null);

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/channel/slack/SlackChannelTestIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/channel/slack/SlackChannelTestIT.java
@@ -22,6 +22,7 @@ import com.blackducksoftware.integration.hub.alert.TestGlobalProperties;
 import com.blackducksoftware.integration.hub.alert.TestPropertyKey;
 import com.blackducksoftware.integration.hub.alert.channel.ChannelTest;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.distribution.SlackDistributionConfigEntity;
+import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.global.GlobalHubRepository;
 import com.blackducksoftware.integration.hub.alert.digest.model.ProjectData;
 
@@ -29,10 +30,11 @@ public class SlackChannelTestIT extends ChannelTest {
 
     @Test
     public void sendMessageTestIT() throws IOException {
+        final AuditEntryRepository auditEntryRepository = Mockito.mock(AuditEntryRepository.class);
         final GlobalHubRepository mockedGlobalRepository = Mockito.mock(GlobalHubRepository.class);
         final TestGlobalProperties globalProperties = new TestGlobalProperties(mockedGlobalRepository, null);
 
-        final SlackChannel slackChannel = new SlackChannel(gson, null, null, globalProperties);
+        final SlackChannel slackChannel = new SlackChannel(gson, auditEntryRepository, null, null, globalProperties);
         final String roomName = properties.getProperty(TestPropertyKey.TEST_SLACK_CHANNEL_NAME);
         final String username = properties.getProperty(TestPropertyKey.TEST_SLACK_USERNAME);
         final String webHook = properties.getProperty(TestPropertyKey.TEST_SLACK_WEBHOOK);

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/datasource/entity/NotificationEntityTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/datasource/entity/NotificationEntityTest.java
@@ -53,7 +53,7 @@ public class NotificationEntityTest {
     public void testModel() {
         final Long id = 123L;
         final String eventKey = "EventKey";
-        final Date createdAt = new Date();
+        final Date createdAt = new Date(System.currentTimeMillis());
         final String notificationType = "NotificationType";
         final String projectName = "ProjectName";
         final String projectUrl = "projectUrl";

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/AuditEntryRepositoryTestIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/datasource/entity/repository/AuditEntryRepositoryTestIT.java
@@ -49,9 +49,9 @@ public class AuditEntryRepositoryTestIT {
         final Date middleDate = new Date(200);
         final Date mostRecent = new Date(300);
 
-        final AuditEntryEntity leastRecentEntity = new AuditEntryEntity(-1L, commonConfigId, null, leastRecent, null, null, null);
-        final AuditEntryEntity middleEntity = new AuditEntryEntity(-1L, commonConfigId, null, middleDate, null, null, null);
-        final AuditEntryEntity mostRecentEntity = new AuditEntryEntity(-1L, commonConfigId, null, mostRecent, null, null, null);
+        final AuditEntryEntity leastRecentEntity = new AuditEntryEntity(commonConfigId, null, leastRecent, null, null, null);
+        final AuditEntryEntity middleEntity = new AuditEntryEntity(commonConfigId, null, middleDate, null, null, null);
+        final AuditEntryEntity mostRecentEntity = new AuditEntryEntity(commonConfigId, null, mostRecent, null, null, null);
         auditEntryRepository.save(leastRecentEntity);
         auditEntryRepository.save(middleEntity);
         auditEntryRepository.save(mostRecentEntity);

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/digest/DigestNotificationProcessorIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/digest/DigestNotificationProcessorIT.java
@@ -93,10 +93,10 @@ public class DigestNotificationProcessorIT {
         notificationActions.saveNotificationTypes(commonDistributionConfigEntity, restModel);
 
         final List<NotificationEntity> notificationList = new ArrayList<>();
-        final NotificationEntity applicableNotification = new NotificationEntity("event_key_1", new Date(), "POLICY_VIOLATION", projectName, "", "", "", "Test Component", "Test Component Version", "Test Policy Rule Name", "Test Person",
-                Collections.emptyList());
-        final NotificationEntity nonApplicableNotification = new NotificationEntity("event_key_2", new Date(), "POLICY_VIOLATION", "Project that we don't care about", "", "", "", "Test Component", "Test Component Version",
+        final NotificationEntity applicableNotification = new NotificationEntity("event_key_1", new Date(System.currentTimeMillis()), "POLICY_VIOLATION", projectName, "", "", "", "Test Component", "Test Component Version",
                 "Test Policy Rule Name", "Test Person", Collections.emptyList());
+        final NotificationEntity nonApplicableNotification = new NotificationEntity("event_key_2", new Date(System.currentTimeMillis()), "POLICY_VIOLATION", "Project that we don't care about", "", "", "", "Test Component",
+                "Test Component Version", "Test Policy Rule Name", "Test Person", Collections.emptyList());
         notificationList.add(applicableNotification);
         notificationList.add(nonApplicableNotification);
 
@@ -127,10 +127,10 @@ public class DigestNotificationProcessorIT {
         notificationActions.saveNotificationTypes(commonDistributionConfigEntity, restModel);
 
         final List<NotificationEntity> notificationList = new ArrayList<>();
-        final NotificationEntity applicableNotification = new NotificationEntity(eventKey, new Date(), "POLICY_VIOLATION", projectName, "", projectVersionName, "", "Test Component", "Test Component Version", "Test Policy Rule Name",
-                "Test Person", Collections.emptyList());
-        final NotificationEntity otherApplicableNotification = new NotificationEntity(eventKey, new Date(), "POLICY_VIOLATION", projectName, "", projectVersionName, "", "Test Component", "Test Component Version", "Test Policy Rule Name",
-                "Test Person", Collections.emptyList());
+        final NotificationEntity applicableNotification = new NotificationEntity(eventKey, new Date(System.currentTimeMillis()), "POLICY_VIOLATION", projectName, "", projectVersionName, "", "Test Component", "Test Component Version",
+                "Test Policy Rule Name", "Test Person", Collections.emptyList());
+        final NotificationEntity otherApplicableNotification = new NotificationEntity(eventKey, new Date(System.currentTimeMillis()), "POLICY_VIOLATION", projectName, "", projectVersionName, "", "Test Component", "Test Component Version",
+                "Test Policy Rule Name", "Test Person", Collections.emptyList());
         notificationList.add(applicableNotification);
         notificationList.add(otherApplicableNotification);
 
@@ -161,10 +161,10 @@ public class DigestNotificationProcessorIT {
         notificationActions.saveNotificationTypes(commonDistributionConfigEntity, restModel);
 
         final List<NotificationEntity> notificationList = new LinkedList<>();
-        final NotificationEntity applicableNotification = new NotificationEntity(eventKey, new Date(), "POLICY_VIOLATION", projectName, "", projectVersionName, "", "Test Component", "Test Component Version", "Test Policy Rule Name",
-                "Test Person", Collections.emptyList());
-        final NotificationEntity nonApplicableNotification = new NotificationEntity(eventKey, new Date(), "POLICY_VIOLATION_CLEARED", projectName, "", projectVersionName, "", "Test Component", "Test Component Version",
+        final NotificationEntity applicableNotification = new NotificationEntity(eventKey, new Date(System.currentTimeMillis()), "POLICY_VIOLATION", projectName, "", projectVersionName, "", "Test Component", "Test Component Version",
                 "Test Policy Rule Name", "Test Person", Collections.emptyList());
+        final NotificationEntity nonApplicableNotification = new NotificationEntity(eventKey, new Date(System.currentTimeMillis()), "POLICY_VIOLATION_CLEARED", projectName, "", projectVersionName, "", "Test Component",
+                "Test Component Version", "Test Policy Rule Name", "Test Person", Collections.emptyList());
         notificationList.add(applicableNotification);
         notificationList.add(nonApplicableNotification);
 

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataBuilderTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataBuilderTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -37,7 +38,7 @@ public class ProjectDataBuilderTest {
         assertNull(projectDataBuilder.getProjectName());
         assertNull(projectDataBuilder.getProjectVersion());
 
-        final ProjectData projectData = new ProjectData(null, null, null, new HashMap<>());
+        final ProjectData projectData = new ProjectData(null, null, null, null, new HashMap<>());
         assertEquals(projectData, projectDataBuilder.build());
     }
 
@@ -67,7 +68,7 @@ public class ProjectDataBuilderTest {
         final Map<NotificationCategoryEnum, CategoryData> categoryMap = new HashMap<>();
         categoryMap.put(NotificationCategoryEnum.HIGH_VULNERABILITY, categoryDataBuilder.build());
 
-        ProjectData projectData = new ProjectData(DigestTypeEnum.DAILY, "Project", "Version", categoryMap);
+        ProjectData projectData = new ProjectData(DigestTypeEnum.DAILY, "Project", "Version", Collections.emptyList(), categoryMap);
         assertEquals(projectData, projectDataBuilder.build());
 
         projectDataBuilder.removeCategoryBuilder(NotificationCategoryEnum.HIGH_VULNERABILITY);
@@ -78,7 +79,7 @@ public class ProjectDataBuilderTest {
         assertEquals("Project", projectDataBuilder.getProjectName());
         assertEquals("Version", projectDataBuilder.getProjectVersion());
 
-        projectData = new ProjectData(DigestTypeEnum.DAILY, "Project", "Version", new HashMap<>());
+        projectData = new ProjectData(DigestTypeEnum.DAILY, "Project", "Version", Collections.emptyList(), new HashMap<>());
         assertEquals(projectData, projectDataBuilder.build());
     }
 

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataBuilderTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataBuilderTest.java
@@ -38,7 +38,7 @@ public class ProjectDataBuilderTest {
         assertNull(projectDataBuilder.getProjectName());
         assertNull(projectDataBuilder.getProjectVersion());
 
-        final ProjectData projectData = new ProjectData(null, null, null, null, new HashMap<>());
+        final ProjectData projectData = new ProjectData(null, null, null, Collections.emptyList(), new HashMap<>());
         assertEquals(projectData, projectDataBuilder.build());
     }
 

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataTest.java
@@ -36,7 +36,7 @@ public class ProjectDataTest {
         assertNull(projectData.getProjectName());
         assertNull(projectData.getProjectVersion());
 
-        assertEquals("{\"digestType\":null,\"projectKey\":null,\"projectName\":null,\"projectVersion\":null,\"categoryMap\":null}", projectData.toString());
+        assertEquals("{\"digestType\":null,\"projectKey\":null,\"projectName\":null,\"projectVersion\":null,\"notificationIds\":null,\"categoryMap\":null}", projectData.toString());
     }
 
     @Test

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataTest.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/digest/model/ProjectDataTest.java
@@ -14,7 +14,9 @@ package com.blackducksoftware.integration.hub.alert.digest.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -26,7 +28,7 @@ public class ProjectDataTest {
 
     @Test
     public void testDataNull() {
-        final ProjectData projectData = new ProjectData(null, null, null, null);
+        final ProjectData projectData = new ProjectData(null, null, null, null, null);
 
         assertNull(projectData.getCategoryMap());
         assertNull(projectData.getDigestType());
@@ -39,16 +41,16 @@ public class ProjectDataTest {
 
     @Test
     public void testProjectKey() {
-        ProjectData projectData = new ProjectData(null, null, null, null);
+        ProjectData projectData = new ProjectData(null, null, null, null, null);
         assertNull(projectData.getProjectKey());
 
-        projectData = new ProjectData(null, null, "Version", null);
+        projectData = new ProjectData(null, null, "Version", null, null);
         assertEquals("Version", projectData.getProjectKey());
 
-        projectData = new ProjectData(null, "Project", null, null);
+        projectData = new ProjectData(null, "Project", null, null, null);
         assertEquals("Project", projectData.getProjectKey());
 
-        projectData = new ProjectData(null, "Project", "Version", null);
+        projectData = new ProjectData(null, "Project", "Version", null, null);
         assertEquals("ProjectVersion", projectData.getProjectKey());
     }
 
@@ -58,7 +60,10 @@ public class ProjectDataTest {
         final Map<NotificationCategoryEnum, CategoryData> categoryMap = new HashMap<>();
         categoryMap.put(NotificationCategoryEnum.HIGH_VULNERABILITY, categoryData);
 
-        final ProjectData projectData = new ProjectData(DigestTypeEnum.REAL_TIME, "Project", "Version", categoryMap);
+        final List<Long> notificationIds = new ArrayList<>();
+        notificationIds.add(1L);
+
+        final ProjectData projectData = new ProjectData(DigestTypeEnum.REAL_TIME, "Project", "Version", notificationIds, categoryMap);
 
         assertEquals(categoryMap, projectData.getCategoryMap());
         assertEquals(DigestTypeEnum.REAL_TIME, projectData.getDigestType());
@@ -67,7 +72,7 @@ public class ProjectDataTest {
         assertEquals("Version", projectData.getProjectVersion());
 
         assertEquals(
-                "{\"digestType\":\"REAL_TIME\",\"projectKey\":\"ProjectVersion\",\"projectName\":\"Project\",\"projectVersion\":\"Version\",\"categoryMap\":{HIGH_VULNERABILITY={\"categoryKey\":null,\"itemList\":null,\"itemCount\":0}}}",
+                "{\"digestType\":\"REAL_TIME\",\"projectKey\":\"ProjectVersion\",\"projectName\":\"Project\",\"projectVersion\":\"Version\",\"notificationIds\":[1],\"categoryMap\":{HIGH_VULNERABILITY={\"categoryKey\":null,\"itemList\":null,\"itemCount\":0}}}",
                 projectData.toString());
     }
 }

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/CommonDistributionConfigActionsTestIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/web/actions/distribution/CommonDistributionConfigActionsTestIT.java
@@ -79,7 +79,7 @@ public class CommonDistributionConfigActionsTestIT {
         final Date lastRan = new Date(System.currentTimeMillis());
         final StatusEnum status = StatusEnum.SUCCESS;
 
-        auditEntryRepository.save(new AuditEntryEntity(new Long(-1), new Long(-1), lastRan, lastRan, status, "", ""));
+        auditEntryRepository.save(new AuditEntryEntity(new Long(-1), lastRan, lastRan, status, "", ""));
 
         final CommonDistributionConfigRestModel commonDistributionConfigRestModel = new CommonDistributionConfigRestModel(null, null, distributionType, name, frequency, filterByProject, projectList, notificationTypeList);
         final CommonDistributionConfigActions commonDistributionConfigActions = new CommonDistributionConfigActions(commonDistributionRepository, auditEntryRepository, configuredProjectsActions, notificationTypesActions, objectTransformer);

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/web/controller/handler/AuditEntryHandlerTestIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/web/controller/handler/AuditEntryHandlerTestIT.java
@@ -72,8 +72,7 @@ public class AuditEntryHandlerTestIT {
     public void getTestIT() {
         final NotificationEntity savedNotificationEntity = notificationRepository.save(mockUtils.createNotificationEntity());
         final CommonDistributionConfigEntity savedConfigEntity = commonDistributionRepository.save(mockUtils.createCommonDistributionConfigEntity());
-        final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository
-                .save(new AuditEntryEntity(savedNotificationEntity.getId(), savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.SUCCESS, null, null));
+        final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(new AuditEntryEntity(savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.SUCCESS, null, null));
 
         final List<AuditEntryRestModel> auditEntries = auditEntryHandler.get();
         assertEquals(1, auditEntries.size());
@@ -89,7 +88,7 @@ public class AuditEntryHandlerTestIT {
         final NotificationRestModel notification = auditEntry.getNotification();
         assertEquals(savedNotificationEntity.getEventKey(), notification.getEventKey());
         assertEquals(savedNotificationEntity.getCreatedAt().toString(), notification.getCreatedAt());
-        assertEquals(savedNotificationEntity.getNotificationType(), notification.getNotificationType());
+        assertEquals(savedNotificationEntity.getNotificationType(), notification.getNotificationTypes().get(0));
         assertEquals(savedNotificationEntity.getProjectName(), notification.getProjectName());
         assertEquals(savedNotificationEntity.getProjectVersion(), notification.getProjectVersion());
         assertEquals(savedNotificationEntity.getProjectUrl(), notification.getProjectUrl());
@@ -102,16 +101,12 @@ public class AuditEntryHandlerTestIT {
 
     @Test
     public void resendNotificationTestIt() {
-        final NotificationEntity savedNotificationEntity = notificationRepository.save(mockUtils.createNotificationEntity());
         final CommonDistributionConfigEntity savedConfigEntity = commonDistributionRepository.save(mockUtils.createCommonDistributionConfigEntity());
-        final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository
-                .save(new AuditEntryEntity(savedNotificationEntity.getId(), savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.SUCCESS, null, null));
-        final AuditEntryEntity badAuditEntryEntity_1 = auditEntryRepository
-                .save(new AuditEntryEntity(savedNotificationEntity.getId(), -1L, new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));
+        final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(new AuditEntryEntity(savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.SUCCESS, null, null));
+        final AuditEntryEntity badAuditEntryEntity_1 = auditEntryRepository.save(new AuditEntryEntity(-1L, new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));
         final AuditEntryEntity badAuditEntryEntity_2 = auditEntryRepository
-                .save(new AuditEntryEntity(-1L, savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));
-        final AuditEntryEntity badAuditEntryEntityBoth = auditEntryRepository
-                .save(new AuditEntryEntity(-1L, -1L, new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));
+                .save(new AuditEntryEntity(savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));
+        final AuditEntryEntity badAuditEntryEntityBoth = auditEntryRepository.save(new AuditEntryEntity(-1L, new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));
 
         final ResponseEntity<String> invalidIdResponse = auditEntryHandler.resendNotification(-1L);
         assertEquals(HttpStatus.BAD_REQUEST, invalidIdResponse.getStatusCode());

--- a/src/test/java/com/blackducksoftware/integration/hub/alert/web/controller/handler/AuditEntryHandlerTestIT.java
+++ b/src/test/java/com/blackducksoftware/integration/hub/alert/web/controller/handler/AuditEntryHandlerTestIT.java
@@ -41,6 +41,8 @@ import com.blackducksoftware.integration.hub.alert.datasource.entity.Notificatio
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.AuditEntryRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.CommonDistributionRepository;
 import com.blackducksoftware.integration.hub.alert.datasource.entity.repository.NotificationRepository;
+import com.blackducksoftware.integration.hub.alert.datasource.relation.AuditNotificationRelation;
+import com.blackducksoftware.integration.hub.alert.datasource.relation.repository.AuditNotificationRepository;
 import com.blackducksoftware.integration.hub.alert.enumeration.StatusEnum;
 import com.blackducksoftware.integration.hub.alert.web.model.AuditEntryRestModel;
 import com.blackducksoftware.integration.hub.alert.web.model.NotificationRestModel;
@@ -56,6 +58,8 @@ public class AuditEntryHandlerTestIT {
     private AuditEntryHandler auditEntryHandler;
     @Autowired
     public AuditEntryRepository auditEntryRepository;
+    @Autowired
+    public AuditNotificationRepository auditNotificationRepository;
     @Autowired
     private NotificationRepository notificationRepository;
     @Autowired
@@ -73,6 +77,8 @@ public class AuditEntryHandlerTestIT {
         final NotificationEntity savedNotificationEntity = notificationRepository.save(mockUtils.createNotificationEntity());
         final CommonDistributionConfigEntity savedConfigEntity = commonDistributionRepository.save(mockUtils.createCommonDistributionConfigEntity());
         final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(new AuditEntryEntity(savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.SUCCESS, null, null));
+
+        auditNotificationRepository.save(new AuditNotificationRelation(savedAuditEntryEntity.getId(), savedNotificationEntity.getId()));
 
         final List<AuditEntryRestModel> auditEntries = auditEntryHandler.get();
         assertEquals(1, auditEntries.size());
@@ -101,8 +107,11 @@ public class AuditEntryHandlerTestIT {
 
     @Test
     public void resendNotificationTestIt() {
+        final NotificationEntity savedNotificationEntity = notificationRepository.save(mockUtils.createNotificationEntity());
         final CommonDistributionConfigEntity savedConfigEntity = commonDistributionRepository.save(mockUtils.createCommonDistributionConfigEntity());
         final AuditEntryEntity savedAuditEntryEntity = auditEntryRepository.save(new AuditEntryEntity(savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.SUCCESS, null, null));
+        auditNotificationRepository.save(new AuditNotificationRelation(savedAuditEntryEntity.getId(), savedNotificationEntity.getId()));
+
         final AuditEntryEntity badAuditEntryEntity_1 = auditEntryRepository.save(new AuditEntryEntity(-1L, new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));
         final AuditEntryEntity badAuditEntryEntity_2 = auditEntryRepository
                 .save(new AuditEntryEntity(savedConfigEntity.getId(), new Date(System.currentTimeMillis()), new Date(System.currentTimeMillis()), StatusEnum.FAILURE, "Failed: stuff happened", ""));


### PR DESCRIPTION
Ari noticed that each Audit Entry currently has a Project/Version Component/Version so for each component in a Bom ( that sends a notification) we would have an Audit Entry for. This would be quite noisy.  Then I noticed that (at least for Real Time) we end an Email/HipChat/Slack message per component instead of a Digest of the components. We should look into that and depending on the outcome changes will need to be made to the Audit stuff